### PR TITLE
move map check from disabled to if/else

### DIFF
--- a/clustering/config.json
+++ b/clustering/config.json
@@ -1,3 +1,1 @@
-{
-  "checkboxStatus": true
-}
+{}

--- a/clustering/src/config.ts
+++ b/clustering/src/config.ts
@@ -1,7 +1,0 @@
-import { ImmutableObject } from "seamless-immutable";
-
-export interface Config {
-  checkboxStatus: boolean;
-}
-
-export type IMConfig = ImmutableObject<Config>;

--- a/clustering/src/runtime/translations/default.ts
+++ b/clustering/src/runtime/translations/default.ts
@@ -1,3 +1,3 @@
 export default {
 	_widgetLabel: "Clustering"
-  };
+};

--- a/clustering/src/runtime/widget.tsx
+++ b/clustering/src/runtime/widget.tsx
@@ -2,7 +2,6 @@
 import {React, AllWidgetProps, jsx } from 'jimu-core';
 import {JimuMapViewComponent, JimuMapView} from "jimu-arcgis";
 import {Label, Checkbox, WidgetPlaceholder} from 'jimu-ui';
-import { IMConfig } from "../config";
 
 interface State {
  jimuMapView: JimuMapView;
@@ -11,7 +10,7 @@ interface State {
  errorTip: boolean;
 }
 
-export default class Widget extends React.PureComponent<AllWidgetProps<IMConfig>, State> {
+export default class Widget extends React.PureComponent<AllWidgetProps<any>, State> {
 
  constructor(props){
    super(props);
@@ -98,12 +97,12 @@ renderWidgetPlaceholder() {
  render() {
   const mapContent = <JimuMapViewComponent useMapWidgetId={this.props.useMapWidgetIds?.[0]} onActiveViewChange={this.activeViewChangeHandler} />
   let clusterContent = null;
-  if (this.state.errorTip){
+  if (this.state.errorTip || !(this.props.useMapWidgetIds && this.props.useMapWidgetIds.length > 0)){
     clusterContent = this.renderWidgetPlaceholder();
   } else {
     clusterContent = 
     <Label style={{ cursor: "pointer"}} >
-        <Checkbox  checked={this.state.clusterStatus} disabled={this.props.config.checkboxStatus} onChange={(e) => {this.onCheckBoxChange({
+        <Checkbox  checked={this.state.clusterStatus} onChange={(e) => {this.onCheckBoxChange({
 					target: {
 					  	value: e.target.checked,
 						},

--- a/clustering/src/setting/setting.tsx
+++ b/clustering/src/setting/setting.tsx
@@ -1,26 +1,14 @@
 import {React} from 'jimu-core';
 import {AllWidgetSettingProps} from 'jimu-for-builder';
 import { JimuMapViewSelector, SettingRow, SettingSection} from "jimu-ui/advanced/setting-components";
-import { IMConfig } from "../config";
 
-export default class Setting extends React.PureComponent<AllWidgetSettingProps<IMConfig>, {}>{
+export default class Setting extends React.PureComponent<AllWidgetSettingProps<any>, {}> {
 
   onMapSelected = (useMapWidgetIds: string[]) => {
-    let originMapWidgetIds = []
-    originMapWidgetIds = useMapWidgetIds
-    if (originMapWidgetIds && originMapWidgetIds.length ===0){
-      this.props.onSettingChange({
-        id: this.props.id,
-        useMapWidgetIds: useMapWidgetIds,
-        config: this.props.config.set("checkboxStatus", true)
-      });
-    } else {
-      this.props.onSettingChange({
-        id: this.props.id,
-        useMapWidgetIds: useMapWidgetIds,
-        config: this.props.config.set("checkboxStatus", false)
-      });
-     }
+    this.props.onSettingChange({
+      id: this.props.id,
+      useMapWidgetIds: useMapWidgetIds,
+    });
    };
 
   render(){


### PR DESCRIPTION
instead of disabling the checkbox, moving the logic for when the user does not have a valid map selected to the "if" statement. Also modifying that to use `this.props.useMapWidgetIds` instead of using the config variable. Then removing the config since it's not needed